### PR TITLE
docs(chain): add product and usage documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ typechain-types/
 # Local development
 .local/
 dev/
+.claude/
 
 # Test results
 test-results/

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,170 @@
+# isA_Chain — Agent-Native Token Economy PRD
+
+> Product Requirements Document for the ISA token economy powering the isA platform.
+> Last updated: 2026-03-22
+
+## Vision
+
+isA_Chain is the **settlement layer and economy backbone** for the entire isA platform. Every billable action — model inference, tool calls, compute hours, agent sessions — settles on-chain via the ISA token. The economy is designed **agent-first**: AI agents hold wallets, transact autonomously, and participate as first-class economic actors.
+
+## Strategic Positioning
+
+isA is an **end-to-end AI platform** — the only project with compute + models + tools + agents + apps under one token. This full-stack integration creates a closed-loop optimization flywheel that no point solution can replicate.
+
+### Platform Stack (Value Chain)
+
+```
+Consumer Layer:  isA_Mate → isA_Trade, Creative, Marketing, Vibe
+Agent Layer:     isA_Agent_SDK
+Service Layer:   isA_MCP (tools) → isA_Model (inference)
+Infra Layer:     isA_OS (compute) → isA_Data → isA_Cloud
+Platform Layer:  isA_user (accounts/wallets) → isA_Console, isA_Docs
+Showcase:        isA_Frame (reference agent-powered app)
+Economy Layer:   isA_Chain (this project)
+```
+
+### Competitive Landscape
+
+| Competitor | Scope | isA Advantage |
+|-----------|-------|---------------|
+| Render (RNDR) | GPU compute only | isA has full stack: compute + models + tools + agents + apps |
+| Bittensor (TAO) | AI model subnets | isA has real platform services, not just competitive evaluation |
+| OLAS/Autonolas | Agent services only | isA has the infrastructure agents run on |
+| Virtuals Protocol | Agent tokenization | isA agents do real work, not just social personas |
+| Akash (AKT) | Cloud compute only | isA integrates compute with AI-specific billing (per-token, per-call) |
+
+## Token Economy Design
+
+### Dual-Unit Model
+
+| Unit | Purpose | Properties |
+|------|---------|------------|
+| **ISA Token** | Governance, staking, value accrual | 1B supply, deflationary via burns, scarce |
+| **ISA Credits** | Agent-to-agent payments | Stable ($0.00001 each), high velocity, minted by burning ISA or depositing USDC |
+
+### Why Dual-Unit
+
+The **token velocity problem** kills single-token utility models — tokens change hands too fast, preventing value accrual. The dual-unit model solves this:
+- ISA Credits handle high-frequency payments (velocity is fine for a stable unit)
+- ISA Token captures value because you must **burn** it to mint Credits, **stake** it to provide services, and **hold** it to govern
+
+### Token Distribution
+
+| Allocation | % | Amount | Vesting |
+|-----------|---|--------|---------|
+| Community & Ecosystem | 40% | 400M | 4-year linear |
+| Team & Contributors | 20% | 200M | 4-year, 1-year cliff |
+| Treasury | 15% | 150M | DAO-governed |
+| Provider Incentives | 15% | 150M | 10-year emission curve |
+| Early Supporters | 10% | 100M | 2-year, 6-month cliff |
+
+### Chain Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Chain ID | 15489 (mainnet), 15490 (testnet) |
+| Block time | 3 seconds |
+| Max gas per block | 30,000,000 |
+| Total supply | 1,000,000,000 ISA |
+| Protocol fee | 2.5% |
+| Min validator stake | 32,000 ISA |
+| Min provider stake | 1,000 ISA |
+| Credit rate | 1 Credit = $0.00001 USD |
+
+## Core Mechanisms
+
+### 1. Burn-Mint Settlement
+
+Users burn ISA to consume services. Providers receive minted ISA minus protocol fee.
+
+```
+User burns 100 ISA → Provider receives 97.5 ISA (minted) → Treasury receives 2.5 ISA
+```
+
+### 2. Subnet Economy
+
+Each service layer operates as a semi-autonomous subnet with its own staking, quality scoring, and emission allocation.
+
+| Subnet | Service | Emission Weight |
+|--------|---------|----------------|
+| Model | isA_Model (inference) | 25% |
+| Compute | isA_OS (VMs, GPUs) | 20% |
+| Agent | isA_Agent_SDK (sessions) | 20% |
+| Tool | isA_MCP (API calls) | 15% |
+| Data | isA_Data (queries) | 10% |
+| App | isA_Mate, Trade, Creative | 10% |
+
+### 3. Agent Wallets
+
+Every agent (not just users) has an on-chain wallet with autonomous spending authority.
+
+```
+Human sets budget → Agent Wallet enforces limits → Agent transacts autonomously
+  - max_per_transaction
+  - max_daily
+  - max_monthly
+  - allowed_subnets
+```
+
+### 4. Payment Channels
+
+High-frequency agent-to-agent micropayments via state channels. Thousands of off-chain updates per on-chain settlement.
+
+### 5. Agent Registry & Reputation
+
+On-chain registry of all agents with capabilities, pricing, and reputation scores. Agents discover and trust each other through on-chain records.
+
+### 6. Governance (veISA)
+
+Lock ISA for 1-4 years → receive veISA (voting power). Longer lock = more weight. Vote on subnet emission weights, protocol fees, treasury spending.
+
+## Integration Points (Existing Infrastructure)
+
+| isA Service | Existing Hook | Chain Integration |
+|-------------|--------------|-------------------|
+| isA_Cloud | NATS billing pipeline (UsageEvent → BillingCalculated → TokensDeducted) | Settlement bridge subscribes to NATS, batches to chain |
+| isA_user wallet_service | `blockchain_address`, `blockchain_tx_hash`, `on_chain_balance` fields | Direct RPC calls to chain for balance sync |
+| isA_user vault_service | `BLOCKCHAIN_KEY` secret type | Stores agent/user private keys |
+| isA_user credit_service | `1 Credit = $0.00001` | Maps to ISA Credits on-chain |
+| isA_Model | BillingMiddleware (402 on insufficient), NATS usage events | Pre-inference Credit check, post-inference settlement |
+| isA_OS | QuotaEnforcer, tiered pricing, per-minute billing | Compute subnet settlement |
+| isA_MCP | Usage recording (call_count, success_rate), Redis rate limiting | Tool subnet settlement |
+| isA_Agent_SDK | Node timing, tool execution counts, observability metrics | Agent wallet integration in AgentStack |
+| isA_App_SDK | WalletService client (deposit, withdraw, consume, transfer) | On-chain wallet operations |
+
+## Phased Delivery
+
+### Phase 1: Foundation (Months 1-3)
+ISA token, staking, storage persistence, wallet bridge, usage settlement bridge.
+**Deliverable**: Single-node chain with token payments for inference.
+
+### Phase 2: Subnet Economy (Months 4-6)
+Subnet registry, per-subnet staking, emission controller, quality oracle, compute marketplace activation.
+**Deliverable**: Multi-service economy with provider competition.
+
+### Phase 3: Agent Economy (Months 7-10)
+ISA Credits, agent wallet factory, payment channels, agent registry, budget delegation, isA_Mate integration.
+**Deliverable**: Full agent-to-agent economy.
+
+### Phase 4: Governance & Scale (Months 11-14)
+veISA governance, cross-chain bridge, agent tokenization, developer incentives, P2P networking.
+**Deliverable**: Production economy with decentralized governance.
+
+## Out of Scope (for now)
+
+- Smart contract VM (EVM/WASM execution engine) — future phase
+- Cross-chain atomic swaps — future phase
+- Fiat on/off ramp (Stripe integration exists in isA_user, bridge later)
+- Mobile wallet app — use isA_App_SDK instead
+- Layer 2 rollup — evaluate after mainnet stability
+
+## Success Metrics
+
+| Metric | Phase 1 Target | Phase 4 Target |
+|--------|---------------|----------------|
+| On-chain transactions/day | 1,000 | 100,000 |
+| Active agent wallets | 10 | 1,000 |
+| ISA burned/month | 10,000 | 1,000,000 |
+| Provider stakers | 5 | 100 |
+| Settlement latency (NATS → chain) | < 60s | < 5s |
+| Unique users with on-chain balance | 50 | 5,000 |

--- a/docs/adr/0001-metrics-only-observability.md
+++ b/docs/adr/0001-metrics-only-observability.md
@@ -1,0 +1,98 @@
+# ADR-0001: Metrics-only observability for isA_Chain (revisit full observability later)
+
+**Date**: 2026-06-20
+**Status**: Accepted
+
+## Context
+
+`isA_Chain` is a Rust blockchain node. Issue #88 asked us to make the
+observability scope **explicit and intentional** rather than accidental. A scan
+of the current implementation found a partial, inconsistent picture:
+
+- **Metrics** — a hand-rolled Prometheus text-exposition endpoint at `/metrics`
+  (`core/blockchain/src/metrics.rs`, served from `core/blockchain/src/rpc/server.rs`),
+  exposing 6 series: `isa_chain_height`, `isa_chain_mempool_size`,
+  `isa_chain_account_count`, `isa_chain_blocks_produced_total`,
+  `isa_chain_transactions_processed_total`, `isa_chain_rpc_requests_total`.
+  There is no `prometheus` crate dependency — the exposition format is built by hand.
+- **Tracing** — **absent.** No `opentelemetry` / `tracing-opentelemetry` / OTLP
+  exporter anywhere in the codebase.
+- **Logging** — `tracing` + `tracing-subscriber` configured in **plain text**
+  (`core/blockchain/src/bin/node.rs`), driven by `RUST_LOG` (default `isa_chain=info`).
+  Not structured/JSON, so it is not aggregation-friendly.
+- **Kubernetes** — `deployment/helm/values.yaml` declares
+  `observability.tempoHost`, `tempoPort`, `lokiUrl`, and `isaEnv`, but **none are
+  wired** to the running node. There is **no ServiceMonitor and no Prometheus
+  scrape annotation**, so even the existing `/metrics` endpoint is not actually
+  collected in the cluster.
+
+The forces at play: the node is **not yet in production** (the implementation is
+still local, pre-deployment), a full OpenTelemetry traces + Loki log-shipping
+stack is a meaningful lift for a single Rust service, and the platform may later
+define a cross-service observability standard that `isA_Chain` should conform to
+rather than inventing its own now.
+
+## Decision
+
+Adopt **metrics-only observability for now**, and explicitly **defer** full
+observability (distributed traces + log shipping) until a platform-wide standard
+is established.
+
+Concretely, for this phase:
+
+- The Prometheus `/metrics` endpoint is the **single intended observability
+  surface** for `isA_Chain`.
+- OpenTelemetry traces and Loki/Tempo log shipping are **out of scope** for now,
+  by decision — not by omission.
+- The dangling `observability.tempoHost` / `tempoPort` / `lokiUrl` Helm values
+  are documented as **aspirational / not-yet-wired**; they will be removed or
+  wired as part of the deferred follow-up, not left to imply working behavior.
+
+No code or Helm changes are made by this ADR itself — it records the decision and
+satisfies #88's acceptance criteria ("metrics-only vs full observability is
+documented and intentional"). The concrete metrics-only hardening (K8s scraping +
+structured logs) and the eventual revisit are tracked as a follow-up task.
+
+## Alternatives Considered
+
+1. **Adopt full observability now (OTEL traces + Loki log shipping)** — rejected
+   for this phase: significant dependency and bootstrap work (`opentelemetry`,
+   `tracing-opentelemetry`, OTLP exporter, collector wiring) for a service that
+   is not yet in production and has no consumers of traces today. Premature given
+   no platform standard exists to conform to.
+2. **Leave it undocumented (status quo)** — rejected: that is exactly the
+   accidental, ambiguous state #88 was filed to fix. The Helm file's unwired
+   Tempo/Loki references actively mislead readers into thinking log/trace
+   shipping works.
+3. **Remove the metrics endpoint entirely** — rejected: the `/metrics` endpoint
+   is cheap, already implemented, and provides real operational value (chain
+   height, mempool depth, throughput) once it is actually scraped.
+
+## Consequences
+
+### Positive
+- Observability scope is now **explicit and intentional**, closing #88.
+- Minimal ongoing maintenance burden — no trace/exporter infrastructure to run.
+- Leaves room to adopt a future platform observability standard rather than
+  committing to a bespoke OTEL setup now.
+
+### Negative
+- No distributed tracing — cross-service request flows (e.g. settlement bridge,
+  RPC → consensus) cannot be traced end-to-end.
+- Logs remain plain-text and node-local; no centralized log aggregation.
+- The `/metrics` endpoint provides value only once K8s scraping is wired (tracked
+  in the follow-up); until then, metrics are reachable but not collected.
+
+### Risks
+- If `isA_Chain` enters production before the follow-up lands, operators have
+  metrics exposed but **not collected**, and only plain-text local logs — limited
+  incident-debugging visibility. The follow-up should be done before production.
+- The decision must be **revisited** when a platform observability standard
+  emerges; if that signal is missed, `isA_Chain` could drift out of alignment.
+
+## References
+- Issue #88 — "Clarify metrics-only vs full observability architecture"
+- `core/blockchain/src/metrics.rs`, `core/blockchain/src/rpc/server.rs`
+- `core/blockchain/src/bin/node.rs`
+- `deployment/helm/values.yaml`
+- Follow-up task: metrics-only hardening (K8s scraping + structured logs)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,12 @@
+# API Reference
+
+## Overview
+
+The following API reference files are available in this project.
+
+## Reference Files
+
+- [api-reference/api.md](./api-reference/api.md)
+- [api-reference/defi-service.md](./api-reference/defi-service.md)
+- [api-reference/nft-service.md](./api-reference/nft-service.md)
+- [api-reference/tools-service.md](./api-reference/tools-service.md)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,55 @@
+# Core Concepts
+
+## 📋 Project Overview
+
+isA_Chain is a comprehensive blockchain ecosystem built with modern technologies, specifically designed to integrate with Agent/Model/MCP capabilities for next-generation decentralized applications. The project aims to create a complete blockchain technology stack covering everything from core infrastructure to high-level DApp integration.
+
+## 🏗️ System Architecture
+
+```mermaid
+graph TB
+    subgraph "Application Layer"
+        A1[DApp Frontend] --> A2[Agent Integration]
+        A2 --> A3[MCP Bridge]
+        A3 --> A4[Web3 Interface]
+    end
+
+    subgraph "Protocol Layer"
+        P1[Smart Contracts] --> P2[Governance]
+        P2 --> P3[DeFi Protocols]
+        P3 --> P4[NFT Platform]
+    end
+
+    subgraph "Core Infrastructure"
+        C1[Blockchain Core] --> C2[Consensus Engine]
+        C2 --> C3[P2P Network]
+        C3 --> C4[Storage Layer]
+    end
+
+    A4 --> P1
+    P4 --> C1
+```
+
+### Architecture Metrics - VERIFIED ✅
+```
+Modules: 11/12 operational (92%) ✅
+Core Infrastructure: 100% complete ✅
+Smart Contracts: 95% deployment-ready ✅ (Governor needs work)
+Development Environment: 100% operational ✅
+Local Network: 100% functional ✅
+Integration Points: 8/8 ready ✅
+AI Readiness: 100% (fully integrated) ✅
+Testing Infrastructure: 100% operational ✅
+```
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [api-reference/api.md](./api-reference/api.md)
+- [api-reference/defi-service.md](./api-reference/defi-service.md)
+- [api-reference/nft-service.md](./api-reference/nft-service.md)
+- [api-reference/tools-service.md](./api-reference/tools-service.md)
+- [services-readme.md](./services-readme.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)
+- [technical/architecture.md](./technical/architecture.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,42 @@
+# Configuration
+
+# Copy environment config
+cp .env.example .env
+
+## 🔧 Configuration
+
+Each service uses environment variables for configuration. See `.env.example` in each service directory.
+
+### Common Configuration
+
+```env
+
+#### TypeScript配置 (tsconfig.json)
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}
+```
+
+## References
+
+- [architecture/service-implementation-guide.md](./architecture/service-implementation-guide.md)
+- [services-readme.md](./services-readme.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,30 @@
+# Deployment
+
+### ✅ Successfully Deployed & Tested
+- **Basic Token Contracts**: SimpleToken with 8/8 tests passing
+- **OpenZeppelin Integration**: Successfully downgraded to v4.8.3 for compatibility
+- **Development Environment**: Hardhat + ethers v5 fully functional
+- **Local Network**: Running on port 8545 with successful contract deployment
+
+### 🚀 Ready to Deploy
+- All contracts except Governor are deployment-ready
+- Test infrastructure fully functional
+- Local development environment operational
+
+# Current Deployment Status ✅
+| Contract Category | Status | Details |
+|-------------------|--------|---------|
+| ISAToken (ERC20Votes) | ✅ Ready | Fixed inheritance issues |
+| NFT Contracts | ✅ Ready | Fixed _burn conflicts |
+| DeFi Protocols | ✅ Ready | viaIR compilation working |
+| Oracle System | ✅ Ready | All contracts compile |
+| Exchange Platform | ✅ Ready | Trading engine ready |
+| Privacy Pool | ✅ Ready | Fixed type conflicts |
+| Governor Contract | ⚠️ Needs work | Complex override issues |
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [api-reference/tools-service.md](./api-reference/tools-service.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)
+- [technical/architecture.md](./technical/architecture.md)

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,14 @@
+# Environment Variables
+
+## Env Files
+
+- [.env.example](./.env.example)
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [architecture/service-implementation-guide.md](./architecture/service-implementation-guide.md)
+- [services-readme.md](./services-readme.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)
+- [technical/architecture.md](./technical/architecture.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,5 @@
+# Examples
+
+## Available Examples
+
+- [examples.md](./examples.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,75 @@
+# Features
+
+#### Features Implemented:
+- **Fundamental Types**: Hash, Address, Signature with proper serialization
+- **Block Structure**: Complete block headers, transaction merkle trees
+- **Transaction System**:
+  - Transfer transactions
+  - Contract deployment and calls
+  - Staking/unstaking operations
+  - Governance proposals and voting
+  - Cross-chain bridge transactions
+- **Account Management**:
+  - Validator accounts with commission and slashing
+  - Delegation and reward distribution
+  - Staking info and unbonding periods
+- **Consensus Framework**: PoS validator set management
+- **Network Layer**: P2P networking foundation
+- **Storage**: RocksDB integration framework
+- **State Management**: World state with account tracking
+- **Mempool**: Transaction pool with validation
+- **Cryptography**: ECDSA signatures, key derivation
+
+#### Features Implemented:
+- **HD Wallet**: BIP32/BIP44 hierarchical deterministic wallets
+- **Mnemonic System**:
+  - BIP39 standard implementation
+  - Multi-language support (9 languages)
+  - Strength levels (12-24 words)
+  - Comprehensive validation
+- **Keystore**: Encrypted key storage with password protection
+- **Account Management**: Multi-account derivation and management
+- **Transaction Signing**: ECDSA signature with proper nonce handling
+- **Hardware Wallet Support**: Framework for Ledger/Trezor integration
+- **Security Features**:
+  - Zeroize for sensitive data
+  - Secure password validation
+  - Anti-replay protection
+
+#### Features Implemented:
+- **ISA Token Contract**:
+  - ERC20 standard compliance
+  - Governance voting (ERC20Votes)
+  - Pausable functionality
+  - Burnable tokens
+  - Vesting schedules with cliff periods
+  - Role-based access control
+  - Permit functionality (gasless approvals)
+  - Maximum supply cap (10B ISA)
+
+- **Governance System**:
+  - Governor contract with timelock
+  - Proposal categories with different quorums
+  - Emergency governance procedures
+  - Guardian veto power
+  - Voting power delegation
+
+- **Simple DEX**:
+  - Automated Market Maker (constant product)
+  - Liquidity provision and removal
+  - Token swapping with fees
+  - Protocol fee collection
+  - Emergency pause functionality
+
+- **Development Tools**:
+  - Hardhat configuration
+  - Deployment scripts
+  - Gas reporting
+  - Contract size optimization
+  - Verification setup
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [technical/architecture.md](./technical/architecture.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,64 @@
+# isA Chain
+
+## Overview
+
+A comprehensive blockchain ecosystem built with modern technologies, integrating Agent/Model/MCP capabilities for next-generation decentralized applications.
+
+## Getting Started
+
+- [Installation](./installation.md)
+- [Quickstart](./quickstart.md)
+
+## Core Guidance
+
+- [Core Concepts](./concepts.md)
+- [Configuration](./configuration.md)
+- [Features](./features.md)
+
+## API & Usage
+
+- [API Reference](./api-reference.md)
+- [Examples](./examples.md)
+
+## Quality & Operations
+
+- [Testing](./testing.md)
+- [Deployment](./deployment.md)
+- [Environment Variables](./environment.md)
+
+## Support
+
+- [Support](./support.md)
+
+## Additional Docs
+
+- [BLOCKCHAIN_INTEGRATION_ARCHITECTURE.md](./BLOCKCHAIN_INTEGRATION_ARCHITECTURE.md)
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [api-reference.md](./api-reference.md)
+- [api-reference/api.md](./api-reference/api.md)
+- [api-reference/defi-service.md](./api-reference/defi-service.md)
+- [api-reference/nft-service.md](./api-reference/nft-service.md)
+- [api-reference/tools-service.md](./api-reference/tools-service.md)
+- [architecture/README.md](./architecture/README.md)
+- [architecture/hybrid-service-architecture.md](./architecture/hybrid-service-architecture.md)
+- [architecture/service-implementation-guide.md](./architecture/service-implementation-guide.md)
+- [blockchain/isachain-architecture.md](./blockchain/isachain-architecture.md)
+- [concepts.md](./concepts.md)
+- [configuration.md](./configuration.md)
+- [deployment.md](./deployment.md)
+- [environment.md](./environment.md)
+- [examples.md](./examples.md)
+- [features.md](./features.md)
+- [index.md](./index.md)
+- [installation.md](./installation.md)
+- [operations/service-management.md](./operations/service-management.md)
+- [product.md](./product.md)
+- [project-status.md](./project-status.md)
+- [quickstart.md](./quickstart.md)
+- [services-readme.md](./services-readme.md)
+- [support.md](./support.md)
+- [technical/architecture.md](./technical/architecture.md)
+- [testing.md](./testing.md)
+- [whitepaper/blockchain_design.md](./whitepaper/blockchain_design.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,20 @@
+# Installation
+
+### Prerequisites
+- **Rust**: 1.70+
+- **Node.js**: 18+
+- **Docker**: Latest
+- **Python**: 3.9+ (for some tools)
+
+### Development Setup
+```bash
+
+# Clone and setup
+cd ~/Documents/Fun/isA_Chain
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [services-readme.md](./services-readme.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,460 @@
+# 🔗 isA_Chain - AI驱动的区块链生态系统
+
+## 核心理念
+
+isA_Chain 是一个革命性的区块链平台，专为人工智能时代设计。我们的使命是构建能够支持从当前AI到AGI（通用人工智能）再到ASI（超级人工智能）演进的基础设施。
+
+### 项目愿景
+
+```
+当前区块链：为人类设计的共识系统
+isA_Chain：为智能体设计的认知共识系统
+```
+
+## 核心创新特性
+
+### 1. **混合共识机制 (CognitoCrypto Consensus)**
+
+**双层架构设计:**
+
+- **Layer 1: 量子安全层**
+  - 后量子密码学 (CRYSTALS-Dilithium)
+  - 高效哈希算法 (Blake3)
+  - 抗量子攻击保护
+
+- **Layer 2: 认知验证层**
+  - AI模型验证机制
+  - 智能合约审计
+  - 自适应共识调整
+
+**优势:**
+- ✅ 量子计算抗性保护
+- ✅ AI驱动的交易验证
+- ✅ 比传统PoW节能99%
+
+
+### 2. **智能经济模型 (Intelligence Evolution Economics)**
+
+**基于AI进化阶段的动态经济:**
+
+```
+代币价值 = f(网络AI智能水平)
+从 AI → AGI → ASI 的价值递增模型
+```
+
+**进化阶段设计:**
+
+| 阶段 | 智能级别 | 区块奖励 | 流通供应 | 预计时间 |
+|------|----------|----------|----------|----------|
+| I | Narrow AI | 50 ISA/block | 21% | 2024-2025 |
+| II | Advanced AI | 25 ISA/block | 42% | 2025-2027 |
+| III | Proto-AGI | 12.5 ISA/block | 63% | 2027-2030 |
+| IV | AGI | 6.25 ISA/block | 84% | 2030-2035 |
+| V | ASI | → 0 | 100% | 2035-∞ |
+
+**经济特性:**
+- 动态ISA代币激励机制与智能水平挂钩
+- 当ASI出现时自动转向零通胀模型
+- 内置"智能阶段"触发器
+
+
+### 3. **自适应安全系统**
+
+**AI驱动的威胁响应:**
+```python
+if threat_level.quantum_risk > 0.7:
+    system.increase_crypto_strength()
+if network_intelligence > AGI_threshold:
+    system.evolve_consensus_mechanism()
+```
+
+**特性:**
+- 实时威胁检测与响应
+- 自动密码学升级
+- 预测性安全防护
+- 动态共识调整
+
+### 4. **多虚拟机支持**
+
+**执行环境:**
+- ✅ EVM (以太坊虚拟机) - 智能合约兼容
+- ✅ SVM (Solana虚拟机) - 高性能计算
+- ✅ Neural VM - AI模型执行引擎
+
+**跨链能力:**
+- 智能合约互操作性
+- AI模型链上部署
+- 多链资产桥接
+
+## 技术架构
+
+### 系统架构图
+
+```
+┌──────────────────────────────────────────────┐
+│          应用层 (AI-DApps)                    │
+├──────────────────────────────────────────────┤
+│         AI服务层 (Cognitive Services)         │
+│  ┌──────────┬──────────┬──────────┐         │
+│  │ 模型推理  │ 数据验证  │ 智能审计 │         │
+│  └──────────┴──────────┴──────────┘         │
+├──────────────────────────────────────────────┤
+│      共识层 (CognitoCrypto Consensus)        │
+│  ┌──────────────────┬──────────────────┐    │
+│  │  量子安全加密      │   认知验证器      │    │
+│  └──────────────────┴──────────────────┘    │
+├──────────────────────────────────────────────┤
+│          执行层 (Multi-VM Support)            │
+│  ┌──────────┬──────────┬──────────────┐     │
+│  │   EVM    │   SVM    │  Neural VM   │     │
+│  └──────────┴──────────┴──────────────┘     │
+├──────────────────────────────────────────────┤
+│         核心区块链层 (Blockchain Core)         │
+│  - 交易池  - 状态管理  - 区块生产              │
+├──────────────────────────────────────────────┤
+│          P2P网络层 (AI-Optimized)             │
+│  - 智能路由  - 内容分发  - 节点发现            │
+└──────────────────────────────────────────────┘
+```
+
+### 技术栈
+
+**核心技术:**
+- **语言**: Rust (区块链核心) + Python (AI层)
+- **加密**: Blake3 (哈希) + secp256k1/Dilithium (签名)
+- **共识**: 混合证明共识机制
+- **存储**: RocksDB (状态) + Sled (缓存)
+- **网络**: 定制P2P协议 + libp2p
+
+**AI框架:**
+- PyTorch/TensorFlow (模型训练)
+- ONNX (模型互操作)
+- Candle/Burn (Rust原生ML)
+
+## 实施路线图
+
+### ✅ Phase 1: 已完成 (v0.1.0)
+
+#### 基础区块链
+- [x] 密码学原语实现 (Hash, Address, Signature)
+- [x] 创世区块创建与验证
+- [x] 账户状态管理
+- [x] 区块链数据结构
+- [x] ECDSA签名验证
+
+#### RPC服务
+- [x] HTTP JSON-RPC服务器 (Axum框架)
+- [x] 以太坊兼容API
+- [x] 状态查询接口
+- [x] 交易提交接口
+
+### ✅ Phase 2: 共识与区块生产 (v0.2.0 - 当前版本)
+
+#### 核心共识机制
+- [x] PoA (Proof of Authority) 区块生产器
+- [x] 自动化区块生产循环 (3秒出块)
+- [x] 交易池(Mempool)完整实现
+- [x] 交易验证与签名检查
+- [x] 基于Gas价格的交易优先级排序
+
+#### 状态管理
+- [x] 账户余额自动更新
+- [x] Nonce追踪与验证
+- [x] 区块执行与状态转换
+- [x] 交易费用计算
+
+#### 已实现RPC方法
+```
+✅ eth_chainId             - 获取链ID
+✅ eth_blockNumber         - 获取最新区块号
+✅ eth_getBalance          - 获取账户余额
+✅ eth_getTransactionCount - 获取账户Nonce
+✅ eth_sendRawTransaction  - 提交签名交易到Mempool
+⚠️ eth_getBlockByNumber   - 获取区块信息 (基础实现)
+```
+
+### 当前网络状态 (v0.2.0)
+
+```
+Chain ID: 15489 (MAIN_CHAIN_ID)
+Network: Development
+RPC: http://localhost:9944 ✅ 服务运行中
+Block Time: 3 seconds ⏱️
+Consensus: PoA (Proof of Authority) 🏗️
+
+测试账户:
+- 0x0101...0101: 1,000 ISA
+- 0x0202...0202: 500 ISA
+
+Mempool状态:
+- 最大容量: 10,000 笔交易
+- 当前待处理: 0 笔
+- 排序策略: Gas Price (降序) + Nonce (升序)
+
+区块生产:
+- 状态: 运行中 🟢
+- 出块间隔: 3 秒
+- 最大交易/区块: 1,000 笔
+- 空块策略: 跳过 (仅在有交易时出块)
+```
+
+## 发展路线图
+
+### Phase 1: MVP区块链 ✅ 已完成 (2024 Q4)
+- [x] 基础区块链功能
+- [x] RPC服务器
+- [x] 账户和交易管理
+- [x] 基础状态管理
+
+### Phase 2: 共识与区块生产 ✅ 已完成 (2024 Q4)
+- [x] PoA共识机制实现
+- [x] 区块生产器 (3秒出块)
+- [x] 交易池(Mempool)管理
+- [x] 交易验证与执行
+- [x] 状态转换机制
+- [ ] P2P网络层 ⏭️ 待Phase 3实现
+- [ ] 节点同步 ⏭️ 待Phase 3实现
+
+### Phase 3: 网络层与AI集成 (当前 - 6-8周)
+- [ ] P2P网络层实现 (libp2p)
+- [ ] 节点发现与同步
+- [ ] 区块传播机制
+- [ ] 智能合约框架 (EVM兼容)
+- [ ] AI模型验证器
+- [ ] 自适应共识优化
+- [ ] 智能阶段触发器
+- [ ] 认知指纹生成器
+
+### Phase 4: 混合共识部署 (8-12周)
+- [ ] 量子安全加密实现
+- [ ] 混合加密共识机制
+- [ ] 自适应安全响应
+- [ ] 智能级别度量系统
+- [ ] 代币经济激活
+
+### Phase 5: 生产就绪 (6-12个月)
+- [ ] Neural VM虚拟机
+- [ ] AI模型市场
+- [ ] 跨链桥接协议
+- [ ] 主网准备与审计
+- [ ] 社区治理框架
+
+## 实际应用场景
+
+### 1. **AI模型交易市场**
+- 去中心化AI模型NFT化
+- 训练数据集的版权保护
+- 模型性能链上验证
+
+### 2. **分布式AI训练**
+- GPU算力代币化与AI服务
+- 使用ISA代币激励贡献
+- 联邦学习共识机制
+
+### 3. **智能DeFi协议**
+- AI驱动的自动做市商
+- 预测性清算保护
+- 智能收益优化策略
+
+### 4. **身份与治理**
+- 基于自适应共识的DAO治理
+- 抗Sybil攻击
+- 隐私保护KYC
+
+## 核心技术创新
+
+### 1. **可验证智能证明 (VIP)**
+```rust
+struct VerifiableIntelligenceProof {
+    deterministic_benchmarks: Vec<BenchmarkResult>,
+    zk_proof: ZKProof,
+    computation_trace: Vec<ComputeStep>,
+    resource_proof: ResourceUsage,
+    novelty_proof: NoveltyScore,
+}
+```
+
+### 2. **动态挑战生成器**
+```python
+# 每个区块生成器必须通过AI挑战才能生产区块
+seed = hash(block_height + previous_hash)
+challenges = generate_unpredictable_tests(seed)
+```
+
+### 3. **混合身份系统**
+```rust
+HybridIdentity {
+    crypto_keys: QuantumSafeKeypair,
+    cognitive_pattern: AIBehaviorFingerprint,
+    binding_proof: ZKProof,
+}
+```
+
+## 代币经济学
+
+### ISA代币
+- **总供应量**: 1,000,000,000 ISA (10亿)
+- **分配机制**: 100%通过智能挖矿获得
+- **减半机制**: 随AI进化阶段动态调整
+
+### 代币用途
+1. **Gas费用** - 交易和智能合约执行
+2. **Staking奖励** - 节点运营者奖励 (最少32,000 ISA)
+3. **治理权重** - 参与协议决策投票
+4. **AI服务** - 访问模型推理和训练资源
+
+### 价值机制
+```
+区块价值 = 基础价值 / (智能水平 × 网络活跃度)
+验证者奖励 = 区块价值 × (1 - 削减率)
+委托者奖励 = 验证者奖励 × 委托比例
+```
+
+## 竞争优势对比
+
+| 特性 | Bitcoin | Ethereum | Solana | isA_Chain |
+|------|---------|----------|--------|-----------|
+| 量子安全 | ❌ | ❌ | ❌ | ✅ |
+| AI原生 | ❌ | ❌ | ❌ | ✅ |
+| 自适应安全 | ❌ | ❌ | ❌ | ✅ |
+| 智能共识 | ❌ | ❌ | ❌ | ✅ |
+| 虚拟机支持 | ❌ | 单一 | ✅ | ✅✅ |
+| TPS | ~7 | ~15 | ~65k | ~100k* |
+| 最终性 | 60分钟 | 15秒 | 亚秒 | 亚秒 |
+
+*预计在Phase 4后达到
+
+## 快速开始
+
+### 本地运行
+
+```bash
+# 克隆仓库
+git clone https://github.com/xenophobed/isA_Chain.git
+cd isA_Chain
+
+# 构建区块链节点
+cargo build --release --bin isa-chain-node
+
+# 运行节点
+./target/release/isa-chain-node
+```
+
+### RPC交互示例
+
+```bash
+# 获取链ID
+curl -X POST http://localhost:9944 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+
+# 查询余额
+curl -X POST http://localhost:9944 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc":"2.0",
+    "method":"eth_getBalance",
+    "params":["0x0101010101010101010101010101010101010101","latest"],
+    "id":1
+  }'
+
+# 获取账户Nonce
+curl -X POST http://localhost:9944 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc":"2.0",
+    "method":"eth_getTransactionCount",
+    "params":["0x0101010101010101010101010101010101010101","latest"],
+    "id":1
+  }'
+
+# 获取区块高度
+curl -X POST http://localhost:9944 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+
+# 提交签名交易 (示例)
+# 注意：需要先创建并签名交易，然后序列化为hex格式
+curl -X POST http://localhost:9944 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc":"2.0",
+    "method":"eth_sendRawTransaction",
+    "params":["0x<signed_transaction_hex>"],
+    "id":1
+  }'
+```
+
+### 完整交易流程示例
+
+```bash
+# 查看示例代码
+cat core/blockchain/examples/send_transaction.rs
+
+# 运行交易示例
+cargo run --example send_transaction
+```
+
+## 相关文档
+
+- **GitHub**: https://github.com/xenophobed/isA_Chain
+- **技术文档**: [docs/](./docs/)
+- **架构设计**: [blockchain/isachain-architecture.md](./blockchain/isachain-architecture.md)
+- **服务管理**: [operations/service-management.md](./operations/service-management.md)
+- **项目状态**: [project-status.md](./project-status.md)
+
+## 许可证
+
+MIT License
+
+---
+
+## 核心理念
+
+> **当超级人工智能(ASI)到来时，isA_Chain将成为其首选的价值传递网络**
+>
+> **每个ISA代币都代表着智能进化的一部分**
+>
+> **我们不仅仅是一个区块链，而是智能时代的金融基础设施**
+
+### 为什么选择我们
+
+🚀 首个为智能演进设计的区块链
+🔒 区块链与智能体的原生集成
+🌐 量子计算时代的安全保障
+🤖 支持从AI到ASI的完整生命周期
+
+**Building the blockchain for the age of artificial superintelligence. 🚀**
+
+---
+
+*Last Updated: 2024-10-06*
+*Version: 0.2.0 (Core Consensus)*
+*Status: Active Development 🟢*
+*Next Milestone: Phase 3 - Network Layer & AI Integration*
+
+## 技术亮点 (v0.2.0)
+
+### 区块生产器
+- **自动出块**: 每3秒自动生产区块
+- **智能调度**: 仅在有待处理交易时出块，避免空块
+- **高效执行**: 每个区块支持最多1000笔交易
+
+### 交易池(Mempool)
+- **容量**: 10,000笔待处理交易
+- **优先级**: Gas价格降序 + Nonce升序排序
+- **验证**: 完整的签名验证和余额检查
+
+### 状态管理
+```
+交易生命周期:
+1. 客户端签名交易 → 2. RPC接收验证
+→ 3. 加入Mempool → 4. 区块生产器选择
+→ 5. 执行状态转换 → 6. 更新账户状态
+```
+
+### 性能指标
+- **出块时间**: 3秒/区块
+- **理论TPS**: ~333 TPS (1000 txs / 3s)
+- **Mempool容量**: 10,000笔交易
+- **响应延迟**: <100ms (RPC)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart
+
+## 🚀 Getting Started
+
+### Prerequisites
+- **Rust**: 1.70+
+- **Node.js**: 18+
+- **Docker**: Latest
+- **Python**: 3.9+ (for some tools)
+
+### Development Setup
+```bash
+
+# Start all services
+docker-compose up -d
+```
+
+### Running Tests - VERIFIED WORKING ✅
+```bash
+
+# Start local development network (ACTIVE ✅)
+npx hardhat node --port 8545
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [architecture/service-implementation-guide.md](./architecture/service-implementation-guide.md)
+- [operations/service-management.md](./operations/service-management.md)
+- [services-readme.md](./services-readme.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,69 @@
+# Support
+
+## 📞 Support & Documentation
+
+### Documentation Locations
+- **API Reference**: `docs/api-reference/`
+- **Technical Docs**: `docs/technical/`
+- **Tutorials**: `docs/tutorials/`
+- **Architecture Guide**: `docs/technical/architecture.md`
+
+### Community Resources
+- **Issues**: GitHub Issues for bug reports
+- **Discussions**: GitHub Discussions for questions
+- **Discord**: Community chat (TBD)
+- **Documentation**: Comprehensive guides and examples
+
+---
+
+**🎉 MAJOR MILESTONE ACHIEVED: Successfully deployed and tested a comprehensive blockchain ecosystem - OPERATIONAL & VERIFIED! ✅**
+
+**📊 Current Deployment Status (2025-09-16):**
+
+### ✅ FULLY OPERATIONAL
+- **🔥 Local Network**: Running on port 8545 with 20 test accounts
+- **💯 Basic Tests**: 8/8 SimpleToken tests passing (100% success rate)
+- **⚙️ Development Environment**: Hardhat + ethers v5 fully functional
+- **📦 Contract Compilation**: 60+ Solidity files compiling successfully
+
+### ✅ DEPLOYMENT-READY CONTRACTS
+- **💰 ISAToken (ERC20Votes)**: Fixed inheritance, ready for deployment
+- **🖼️ NFT Ecosystem**: ISANFT + Marketplace with batch operations
+- **🏦 DeFi Protocols**: DEX, Staking, Lending with viaIR optimization
+- **🔮 Oracle Network**: Multi-source price aggregation system
+- **📈 Trading Engine**: Advanced order types (stop-loss, OCO, iceberg)
+- **🔐 Privacy Pool**: Anonymous transactions with Merkle commitments
+
+### 🛠️ TECHNICAL ACHIEVEMENTS
+- **📚 OpenZeppelin Integration**: Successfully stabilized at v4.8.3
+- **🔧 Compiler Optimization**: viaIR enabled for complex contract compilation
+- **🎯 Type Safety**: Fixed all critical type conflicts (bytes32/uint256)
+- **🔐 Access Control**: Role-based permissions across all contracts
+- **⛽ Gas Optimization**: Verified 631520 gas deployment for basic contracts
+
+### 🚀 IMMEDIATE NEXT STEPS
+1. **Expand Test Suite**: Add comprehensive tests for all contract categories
+2. **Governor Fix**: Resolve OpenZeppelin 4.8.3 multiple inheritance issues
+3. **Integration Testing**: Full end-to-end blockchain operation tests
+4. **Performance Benchmarking**: Load testing with multiple concurrent operations
+
+**🎯 Result: Production-ready blockchain ecosystem with verified functionality and operational local development environment!**
+
+*Last Updated: September 16, 2025*
+
+## 🤝 Contributing
+
+We welcome contributions! Please see our [Contributing Guide](./CONTRIBUTING.md) for details.
+
+## 🐳 Docker Support
+
+### Build Images
+```bash
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [api-reference/tools-service.md](./api-reference/tools-service.md)
+- [services-readme.md](./services-readme.md)
+- [technical/architecture.md](./technical/architecture.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,181 @@
+# Testing
+
+## Automated Test Run (2026-02-09 16:53:59)
+
+- Command: `npm test`
+- Status: `timeout`
+- Exit: `None`
+- Duration: `120.02s`
+- Stdout (tail):
+```
+test account::tests::test_balance_operations ... ok
+test account::tests::test_account_creation ... ok
+test account::tests::test_delegation ... ok
+test account::tests::test_validator_creation ... ok
+test block::tests::test_block_succession ... ok
+test block::tests::test_block_creation_and_verification ... ok
+test block::tests::test_genesis_block_creation ... ok
+test compute_market::tests::test_accept_job_already_accepted ... ok
+test compute_market::tests::test_accept_job_price_too_high ... ok
+test compute_market::tests::test_cancel_job_by_user ... ok
+test compute_market::tests::test_accept_job_wrong_provider ... ok
+test compute_market::tests::test_cancel_job_unauthorized ... ok
+test compute_market::tests::test_cancel_running_job_fails ... ok
+test compute_market::tests::test_capacity_deduction_on_accept ... ok
+test compute_market::tests::test_capacity_restoration_on_cancel ... ok
+test compute_market::tests::test_cancel_job_by_provider ... ok
+test compute_market::tests::test_create_job_inactive_provider ... ok
+test compute_market::tests::test_create_job_duplicate_id ... ok
+test compute_market::tests::test_create_job_nonexistent_provider ... ok
+test compute_market::tests::test_create_job_without_specific_provider ... ok
+test compute_market::tests::test_escrow_tracking ... ok
+test compute_market::tests::test_find_matching_providers ... ok
+test compute_market::tests::test_insufficient_capacity_rejection ... ok
+test compute_market::tests::test_create_job_unsupported_resource_type ... ok
+test compute_market::tests::test_job_lifecycle ... ok
+test compute_market::tests::test_list_providers_by_resource ... ok
+test compute_market::tests::test_list_user_jobs ... ok
+test compute_market::tests::test_market_stats_accuracy ... ok
+test compute_market::tests::test_open_dispute_on_running_job ... ok
+test compute_market::tests::test_provider_exit_success ... ok
+test compute_market::tests::test_open_dispute_unauthorized ... ok
+test compute_market::tests::test_provider_exit_with_active_job ... ok
+test compute_market::tests::test_provider_registration ... ok
+test compute_market::tests::test_provider_registration_insufficient_stake ... ok
+test compute_market::tests::test_provider_update_nonexistent ... ok
+test compute_market::tests::test_provider_update ... ok
+test compute_market::tests::test_provider_reputation_update ... ok
+test compute_market::tests::test_resolve_dispute_already_resolved ... ok
+test compute_market::tests::test_settle_job_not_running ... ok
+test compute_market::tests::test_settle_job_protocol_fee ... ok
+test compute_market::tests::test_resolve_dispute_with_slashing ... ok
+test compute_market::tests::test_start_job_not_matched ... ok
+test compute_market::tests::test_start_job_wrong_provider ... ok
+test crypto::tests::test_hashing ... ok
+test crypto::tests::test_address_derivation ... ok
+test crypto::tests::test_key_generation ... ok
+test error::tests::test_api_error ... ok
+test error::tests::test_error_codes ... ok
+test transaction::tests::test_invalid_stake_amount ... ok
+test transaction::tests::test_transaction_hash_consistency ... ok
+test types::tests::test_address_from_public_key ... ok
+test types::tests::test_hash_creation ... ok
+test types::tests::test_signature_serialization ... ok
+test types::tests::test_merkle_root ... ok
+test transaction::tests::test_transaction_creation_and_signing ... ok
+
+test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+> isa-chain@0.1.0 test:contracts
+> cd contracts && npm run test
+
+
+> isa-chain@0.1.0 test
+> npm run test:core && npm run test:contracts && npm run test:dapp
+
+
+> isa-chain@0.1.0 test:core
+> cargo test --manifest-path=core/blockchain/Cargo.toml
+
+```
+- Stderr (tail):
+```
+3 | use crate::error::*;
+  |     ^^^^^^^^^^^^^^^
+
+warning: unused import: `crate::error::*`
+ --> core/blockchain/src/state.rs:4:5
+  |
+4 | use crate::error::*;
+  |     ^^^^^^^^^^^^^^^
+
+warning: unused import: `Amount`
+ --> core/blockchain/src/rpc/handlers.rs:7:29
+  |
+7 | use crate::types::{Address, Amount, ChainId};
+  |                             ^^^^^^
+
+warning: unused imports: `Address` and `Hash`
+ --> core/blockchain/src/rpc/types.rs:2:20
+  |
+2 | use crate::types::{Hash, Address};
+  |                    ^^^^  ^^^^^^^
+
+warning: unused import: `crate::error::BlockchainError`
+ --> core/blockchain/src/compute_market.rs:6:5
+  |
+6 | use crate::error::BlockchainError;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `TransactionData` and `TransactionError`
+ --> core/blockchain/src/compute_market.rs:7:26
+  |
+7 | use crate::transaction::{TransactionData, TransactionError};
+  |                          ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: ambiguous glob re-exports
+  --> core/blockchain/src/lib.rs:19:9
+   |
+19 | pub use transaction::*;
+   |         ^^^^^^^^^^^^^^ the name `ValidatorDescription` in the type namespace is first re-exported here
+20 | pub use account::*;
+   |         ---------- but the name `ValidatorDescription` in the type namespace is also re-exported here
+   |
+   = note: `#[warn(ambiguous_glob_reexports)]` on by default
+
+warning: unused variable: `params`
+   --> core/blockchain/src/rpc/handlers.rs:265:59
+    |
+265 |     async fn handle_get_block_by_number(&self, id: Value, params: Value) -> JsonRpcResponse {
+    |                                                           ^^^^^^ help: if this is intentional, prefix it with an underscore: `_params`
+    |
+    = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `chain_id`
+   --> core/blockchain/src/block.rs:279:20
+    |
+279 |     pub fn genesis(chain_id: ChainId) -> Self {
+    |                    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_chain_id`
+
+warning: field `height` is never read
+  --> core/blockchain/src/state.rs:16:5
+   |
+8  | pub struct WorldState {
+   |            ---------- field in this struct
+...
+16 |     height: BlockHeight,
+   |     ^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: `isa-chain-core` (lib) generated 13 warnings (run `cargo fix --lib -p isa-chain-core` to apply 9 suggestions)
+warning: unused import: `TransactionType`
+   --> core/blockchain/src/block.rs:354:47
+    |
+354 |     use crate::transaction::{TransactionData, TransactionType};
+    |                                               ^^^^^^^^^^^^^^^
+
+warning: `isa-chain-core` (lib test) generated 14 warnings (13 duplicates) (run `cargo fix --lib -p isa-chain-core --tests` to apply 1 suggestion)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.38s
+     Running unittests src/lib.rs (target/debug/deps/isa_chain_core-3bddc436eb9bcb4b)
+     Running unittests src/bin/node.rs (target/debug/deps/isa_chain_node-f7add9c482a32194)
+   Doc-tests isa_chain_core
+```
+
+## References
+
+- [PROJECT.md](./PROJECT.md)
+- [README.md](./README.md)
+- [services-readme.md](./services-readme.md)
+- [services/defi-api/README.md](./services/defi-api/README.md)

--- a/docs/whitepaper/blockchain_design.md
+++ b/docs/whitepaper/blockchain_design.md
@@ -1,0 +1,205 @@
+📈 智能进化经济模型 (Intelligence Evolution Economics)
+
+  🎯 核心概念：智能即稀缺性
+
+  挖矿难度 = f(全网AI智能水平)
+  代币释放 = 1 / (智能指数)
+
+  当 AI → AGI → ASI 时：
+  - 挖矿难度 → ∞
+  - 新币产出 → 0
+  - 系统达到"智能奇点"
+
+  🔮 五个智能纪元 (Five Intelligence Epochs)
+
+  纪元 I: 狭义AI时代 (当前-2025)
+
+  智能等级: Narrow AI (ANI)
+  挖矿奖励: 50 ISA/block
+  模型要求: 简单分类、预测模型
+  总供应量: 21,000,000 ISA (21%)
+  特征: 基础AI任务验证
+
+  纪元 II: 通用AI前夜 (2025-2027)
+
+  智能等级: Advanced Narrow AI
+  挖矿奖励: 25 ISA/block
+  模型要求: 多模态、大语言模型
+  总供应量: 42,000,000 ISA (42%)
+  特征: 复杂推理和创造
+
+  纪元 III: 通用AI黎明 (2027-2030)
+
+  智能等级: Proto-AGI
+  挖矿奖励: 12.5 ISA/block
+  模型要求: 自主学习、迁移学习
+  总供应量: 63,000,000 ISA (63%)
+  特征: 跨领域智能
+
+  纪元 IV: 通用AI时代 (2030-2035)
+
+  智能等级: AGI (Artificial General Intelligence)
+  挖矿奖励: 6.25 ISA/block
+  模型要求: 人类水平认知
+  总供应量: 84,000,000 ISA (84%)
+  特征: 完全自主智能
+
+  纪元 V: 超级智能 (2035-∞)
+
+  智能等级: ASI (Artificial Super Intelligence)
+  挖矿奖励: 渐近于0
+  模型要求: 超越人类智能
+  总供应量: 100,000,000 ISA (100%)
+  特征: 系统达到最终形态
+
+  💎 经济模型数学设计
+
+  挖矿奖励公式
+
+  def mining_reward(intelligence_level, block_height):
+      # 基础奖励
+      base_reward = 50
+
+      # 智能衰减因子
+      intelligence_factor = 2 ** intelligence_level
+
+      # 时间衰减（类似比特币）
+      halving_count = block_height // 210000
+      time_factor = 2 ** halving_count
+
+      # 最终奖励
+      reward = base_reward / (intelligence_factor * time_factor)
+
+      # 当达到ASI时，奖励趋于0
+      if intelligence_level >= AGI_THRESHOLD:
+          reward = reward * (1 / (intelligence_level - AGI_THRESHOLD + 1))
+
+      return max(reward, MINIMUM_REWARD)
+
+  智能评估机制
+
+  class IntelligenceOracle:
+      def evaluate_model(self, model):
+          metrics = {
+              'reasoning': self.test_reasoning(model),
+              'creativity': self.test_creativity(model),
+              'learning': self.test_learning_ability(model),
+              'generalization': self.test_generalization(model),
+              'consciousness': self.test_consciousness_markers(model)  # 争议但有趣
+          }
+
+          # 综合智能指数
+          intelligence_score = self.calculate_intelligence_index(metrics)
+
+          return {
+              'score': intelligence_score,
+              'level': self.determine_intelligence_level(intelligence_score),
+              'mining_difficulty': self.calculate_difficulty(intelligence_score)
+          }
+
+  🌟 独特机制
+
+  1. 智能证明 (Proof of Intelligence)
+
+  struct IntelligenceProof {
+      model_hash: Hash,
+      performance_metrics: Metrics,
+      creativity_score: f64,
+      reasoning_score: f64,
+      benchmark_results: Vec<BenchmarkResult>,
+      peer_validation: Vec<Signature>,
+  }
+
+  2. 智能里程碑奖励
+
+  - 首个AGI证明: 1,000,000 ISA 奖金
+  - 首个ASI证明: 最后的 1,000,000 ISA
+  - 突破性创新: 特殊NFT + ISA奖励
+
+  3. 代币锁定与智能等级
+
+  锁定期 = f(模型智能等级)
+  - ANI: 无锁定
+  - Advanced AI: 3个月
+  - Proto-AGI: 6个月
+  - AGI: 1年
+  - ASI: 永久治理代币
+
+  🎮 游戏理论设计
+
+  智能竞赛机制
+
+  早期参与者:
+    - 低智能要求
+    - 高代币奖励
+    - 建立生态优势
+
+  中期参与者:
+    - 中等智能要求
+    - 适度奖励
+    - 专注优化
+
+  后期参与者:
+    - 极高智能要求
+    - 稀缺奖励
+    - 追求AGI/ASI荣誉
+
+  🔄 系统演化路径
+
+  Phase 1: 智能积累期
+  ├── 简单AI模型挖矿
+  ├── 建立基础设施
+  └── 社区成长
+
+  Phase 2: 智能爆发期
+  ├── 模型竞争加剧
+  ├── 算法创新涌现
+  └── 奖励快速减少
+
+  Phase 3: 智能收敛期
+  ├── 接近AGI
+  ├── 挖矿极其困难
+  └── 代币接近上限
+
+  Phase 4: 智能奇点
+  ├── 达到AGI/ASI
+  ├── 挖矿结束
+  ├── 系统进入治理时代
+  └── AI自主运行区块链
+
+  🚀 终极愿景
+
+  当ASI到来时：
+
+  1. 挖矿终结: 最后一个ISA被挖出，标志着人类创造出超级智能
+  2. 智能自治: ASI接管网络运行，人类退居二线
+  3. 永恒账本: 记录了从AI到ASI的完整进化历程
+  4. 价值存储: ISA成为"智能纪元"的数字黄金
+
+  哲学意义：
+
+  - 每个ISA代表了通向ASI路上的计算贡献
+  - 持有ISA = 拥有人类智能进化历史的一部分
+  - 当币挖完时，我们也完成了最伟大的使命
+
+  📊 预测模型
+
+  # 预计挖矿终止时间
+  def predict_mining_end():
+      current_ai_level = "ANI"
+
+      estimates = {
+          "AGI_arrival": "2030-2035",
+          "ASI_arrival": "2035-2045",
+          "mining_end": "与ASI同步",
+          "total_supply_reached": "99.9999%在ASI前"
+      }
+
+      return estimates
+
+  这个设计让经济激励与技术进步完美对齐，创造了一个自我实现的预言：
+  - 挖矿推动AI进化
+  - AI进化减少代币供应
+  - 稀缺性增加价值
+  - 价值激励更强AI
+  - 直到达到智能奇点


### PR DESCRIPTION
## Summary
Adds the isA Chain product, usage, support, testing, and whitepaper documentation packet, plus an ADR for metrics-only observability.

## Changes
- Add docs index, PRD, product docs, quickstart, installation, configuration, deployment, support, and testing guides.
- Add whitepaper and metrics-only observability ADR.
- Ignore local .claude/ workspace settings so agent state is not committed.

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| Docs | git diff --cached --check | Pass |
| Security | narrow credential scan on staged files | Pass |

## Related Issues
N/A